### PR TITLE
Fix: Auto-resize replaced images to their original dimensions

### DIFF
--- a/template_pptx_jinja/pictures.py
+++ b/template_pptx_jinja/pictures.py
@@ -1,6 +1,6 @@
 import hashlib
 from PIL import Image
-from pptx.util import Inches, Pt, Emu  # Emu = 英制单位，1英寸 = 914400 EMU
+from pptx.util import Inches, Pt, Emu  # Emu = English Metric Unit, 1 inch = 914400 EMU
 
 def get_hash(filename):
     with open(filename, "rb") as f:
@@ -8,25 +8,25 @@ def get_hash(filename):
     sha1 = hashlib.sha1(blob)
     return sha1.hexdigest()
 
-# 替换图片并将尺寸调整为新图的原始尺寸
+# Replace image and resize to the new image's original dimensions
 def replace_img_slide(slide, img_shape, img_path):
-    # Step 1: 读取新图像的二进制
+    # Step 1: Read new image binary data
     with open(img_path, 'rb') as f:
         new_img_blob = f.read()
 
-    # Step 2: 替换图片内容
+    # Step 2: Replace image content
     img_pic = img_shape._pic
     img_rid = img_pic.xpath('./p:blipFill/a:blip/@r:embed')[0]
     img_part = slide.part.related_part(img_rid)
     img_part._blob = new_img_blob
 
-    # Step 3: 获取新图片的尺寸（以像素为单位）
+    # Step 3: Get new image dimensions (in pixels)
     with Image.open(img_path) as im:
         px_width, px_height = im.size
-        dpi = im.info.get("dpi", (96, 96))  # 有些图片不含 DPI 信息，默认 96
+        dpi = im.info.get("dpi", (96, 96))  # Some images don't contain DPI info, default to 96
         inch_width = px_width / dpi[0]
         inch_height = px_height / dpi[1]
 
-    # Step 4: 调整图片形状尺寸（单位为 EMU）
+    # Step 4: Adjust image shape size (in EMU units)
     img_shape.width = Inches(inch_width)
     img_shape.height = Inches(inch_height)

--- a/template_pptx_jinja/pictures.py
+++ b/template_pptx_jinja/pictures.py
@@ -1,8 +1,6 @@
 import hashlib
-
-
 from PIL import Image
-
+from pptx.util import Inches, Pt, Emu  # Emu = 英制单位，1英寸 = 914400 EMU
 
 def get_hash(filename):
     with open(filename, "rb") as f:
@@ -10,16 +8,25 @@ def get_hash(filename):
     sha1 = hashlib.sha1(blob)
     return sha1.hexdigest()
 
-# See https://github.com/scanny/python-pptx/issues/116
-def replace_img_slide(slide, img, img_path):
-    # Replace the picture in the shape object (img) with the image in img_path.
-
-    imgPic = img._pic
-    imgRID = imgPic.xpath('./p:blipFill/a:blip/@r:embed')[0]
-    imgPart = slide.part.related_part(imgRID)
-
+# 替换图片并将尺寸调整为新图的原始尺寸
+def replace_img_slide(slide, img_shape, img_path):
+    # Step 1: 读取新图像的二进制
     with open(img_path, 'rb') as f:
-        rImgBlob = f.read()
+        new_img_blob = f.read()
 
-    # replace
-    imgPart._blob = rImgBlob
+    # Step 2: 替换图片内容
+    img_pic = img_shape._pic
+    img_rid = img_pic.xpath('./p:blipFill/a:blip/@r:embed')[0]
+    img_part = slide.part.related_part(img_rid)
+    img_part._blob = new_img_blob
+
+    # Step 3: 获取新图片的尺寸（以像素为单位）
+    with Image.open(img_path) as im:
+        px_width, px_height = im.size
+        dpi = im.info.get("dpi", (96, 96))  # 有些图片不含 DPI 信息，默认 96
+        inch_width = px_width / dpi[0]
+        inch_height = px_height / dpi[1]
+
+    # Step 4: 调整图片形状尺寸（单位为 EMU）
+    img_shape.width = Inches(inch_width)
+    img_shape.height = Inches(inch_height)


### PR DESCRIPTION
This PR fixes an issue where replaced images in slides remained locked to the original image's dimensions. The changes automatically adjust the size of new images to match their original dimensions, ensuring proper scaling and aspect ratio.

Key changes:

1. Added functionality to read the new image's dimensions in pixels
2. Implemented DPI-based size calculation to convert pixels to inches
3. Adjusted slide shapes to match the new image's dimensions

The fix improves the image replacement process by maintaining the correct proportions of inserted images, preventing distortion or improper scaling.

![PixPin_2025-04-19_06-46-29](https://github.com/user-attachments/assets/415cf691-8bab-4958-9801-59f36c0f75d2)

![PixPin_2025-04-19_07-02-42](https://github.com/user-attachments/assets/7be672ed-f4a0-4e02-96b8-20f84d22b6c5)
