### PR TITLE
fix(pptx): Resolve image replacement sizing + placeholder split-run rendering

### DIFF
--- a/template_pptx_jinja/pictures.py
+++ b/template_pptx_jinja/pictures.py
@@ -1,6 +1,6 @@
 import hashlib
 from PIL import Image
-from pptx.util import Inches, Pt, Emu  # Emu = English Metric Unit, 1 inch = 914400 EMU
+from pptx.util import Inches
 
 def get_hash(filename):
     with open(filename, "rb") as f:
@@ -8,25 +8,43 @@ def get_hash(filename):
     sha1 = hashlib.sha1(blob)
     return sha1.hexdigest()
 
-# Replace image and resize to the new image's original dimensions
 def replace_img_slide(slide, img_shape, img_path):
-    # Step 1: Read new image binary data
-    with open(img_path, 'rb') as f:
-        new_img_blob = f.read()
-
-    # Step 2: Replace image content
+    # Step 1: 替换图片内容
     img_pic = img_shape._pic
     img_rid = img_pic.xpath('./p:blipFill/a:blip/@r:embed')[0]
     img_part = slide.part.related_part(img_rid)
+
+    with open(img_path, 'rb') as f:
+        new_img_blob = f.read()
     img_part._blob = new_img_blob
 
-    # Step 3: Get new image dimensions (in pixels)
+    # Step 2: 获取新图尺寸（像素）和 DPI
     with Image.open(img_path) as im:
-        px_width, px_height = im.size
-        dpi = im.info.get("dpi", (96, 96))  # Some images don't contain DPI info, default to 96
-        inch_width = px_width / dpi[0]
-        inch_height = px_height / dpi[1]
+        px_w, px_h = im.size
+        dpi = im.info.get("dpi", (96, 96))  # 默认 96 DPI
+        inch_w = px_w / dpi[0]
+        inch_h = px_h / dpi[1]
 
-    # Step 4: Adjust image shape size (in EMU units)
-    img_shape.width = Inches(inch_width)
-    img_shape.height = Inches(inch_height)
+    # Step 3: 获取原图形状尺寸和中心位置（单位：EMU）
+    orig_w = img_shape.width
+    orig_h = img_shape.height
+    center_x = img_shape.left + orig_w // 2
+    center_y = img_shape.top + orig_h // 2
+
+    # Step 4: 缩放计算，保持不超出原图区域
+    shape_w_inch = orig_w / 914400
+    shape_h_inch = orig_h / 914400
+    scale_w = shape_w_inch / inch_w
+    scale_h = shape_h_inch / inch_h
+    scale = min(scale_w, scale_h, 1.0)  # 不放大，只等比缩小
+
+    final_w = Inches(inch_w * scale)
+    final_h = Inches(inch_h * scale)
+
+    # Step 5: 应用新尺寸
+    img_shape.width = final_w
+    img_shape.height = final_h
+
+    # Step 6: 将形状重新居中回原图位置
+    img_shape.left = int(center_x - final_w / 2)
+    img_shape.top = int(center_y - final_h / 2)

--- a/template_pptx_jinja/pictures.py
+++ b/template_pptx_jinja/pictures.py
@@ -9,7 +9,7 @@ def get_hash(filename):
     return sha1.hexdigest()
 
 def replace_img_slide(slide, img_shape, img_path):
-    # Step 1: 替换图片内容
+    # Step 1: Replace image content
     img_pic = img_shape._pic
     img_rid = img_pic.xpath('./p:blipFill/a:blip/@r:embed')[0]
     img_part = slide.part.related_part(img_rid)
@@ -18,33 +18,33 @@ def replace_img_slide(slide, img_shape, img_path):
         new_img_blob = f.read()
     img_part._blob = new_img_blob
 
-    # Step 2: 获取新图尺寸（像素）和 DPI
+    # Step 2: Get new image dimensions (pixels) and DPI
     with Image.open(img_path) as im:
         px_w, px_h = im.size
-        dpi = im.info.get("dpi", (96, 96))  # 默认 96 DPI
+        dpi = im.info.get("dpi", (96, 96))  # default 96 DPI
         inch_w = px_w / dpi[0]
         inch_h = px_h / dpi[1]
 
-    # Step 3: 获取原图形状尺寸和中心位置（单位：EMU）
+    # Step 3: Get original shape dimensions and center position (in EMU)
     orig_w = img_shape.width
     orig_h = img_shape.height
     center_x = img_shape.left + orig_w // 2
     center_y = img_shape.top + orig_h // 2
 
-    # Step 4: 缩放计算，保持不超出原图区域
+    # Step 4: Scale calculation to keep within original image area
     shape_w_inch = orig_w / 914400
     shape_h_inch = orig_h / 914400
     scale_w = shape_w_inch / inch_w
     scale_h = shape_h_inch / inch_h
-    scale = min(scale_w, scale_h, 1.0)  # 不放大，只等比缩小
+    scale = min(scale_w, scale_h, 1.0)  # No upscaling, only proportional downscaling
 
     final_w = Inches(inch_w * scale)
     final_h = Inches(inch_h * scale)
 
-    # Step 5: 应用新尺寸
+    # Step 5: Apply new dimensions
     img_shape.width = final_w
     img_shape.height = final_h
 
-    # Step 6: 将形状重新居中回原图位置
+    # Step 6: Re-center the shape to original position
     img_shape.left = int(center_x - final_w / 2)
     img_shape.top = int(center_y - final_h / 2)

--- a/template_pptx_jinja/pictures.py
+++ b/template_pptx_jinja/pictures.py
@@ -1,6 +1,6 @@
 import hashlib
 from PIL import Image
-from pptx.util import Inches, Pt, Emu  # Emu = 英制单位，1英寸 = 914400 EMU
+from pptx.util import Inches, Pt, Emu  # Emu = English Metric Unit, 1 inch = 914400 EMU
 
 def get_hash(filename):
     with open(filename, "rb") as f:
@@ -8,25 +8,25 @@ def get_hash(filename):
     sha1 = hashlib.sha1(blob)
     return sha1.hexdigest()
 
-# 替换图片并将尺寸调整为新图的原始尺寸
+# Replace image and resize to the new image's original dimensions
 def replace_img_slide(slide, img_shape, img_path):
-    # Step 1: 读取新图像的二进制
+    # Step 1: Read new image binary data
     with open(img_path, 'rb') as f:
         new_img_blob = f.read()
 
-    # Step 2: 替换图片内容
+    # Step 2: Replace image content
     img_pic = img_shape._pic
     img_rid = img_pic.xpath('./p:blipFill/a:blip/@r:embed')[0]
     img_part = slide.part.related_part(img_rid)
     img_part._blob = new_img_blob
 
-    # Step 3: 获取新图片的尺寸（以像素为单位）
+    # Step 3: Get new image dimensions (in pixels)
     with Image.open(img_path) as im:
         px_width, px_height = im.size
-        dpi = im.info.get("dpi", (96, 96))  # 有些图片不含 DPI 信息，默认 96
+        dpi = im.info.get("dpi", (96, 96))  # Some images don't contain DPI info, default to 96
         inch_width = px_width / dpi[0]
         inch_height = px_height / dpi[1]
 
-    # Step 4: 调整图片形状尺寸（单位为 EMU）
+    # Step 4: Adjust image shape size (in EMU units)
     img_shape.width = Inches(inch_width)
     img_shape.height = Inches(inch_height)

--- a/template_pptx_jinja/pictures.py
+++ b/template_pptx_jinja/pictures.py
@@ -1,8 +1,6 @@
 import hashlib
-
-
 from PIL import Image
-
+from pptx.util import Inches, Pt, Emu  # Emu = 英制单位，1英寸 = 914400 EMU
 
 def get_hash(filename):
     with open(filename, "rb") as f:
@@ -10,16 +8,25 @@ def get_hash(filename):
     sha1 = hashlib.sha1(blob)
     return sha1.hexdigest()
 
-# See https://github.com/scanny/python-pptx/issues/116
-def replace_img_slide(slide, img, img_path):
-    # Replace the picture in the shape object (img) with the image in img_path.
-
-    imgPic = img._pic
-    imgRID = imgPic.xpath('./p:blipFill/a:blip/@r:embed')[0]
-    imgPart = slide.part.related_part(imgRID)
-
+# 替换图片并将尺寸调整为新图的原始尺寸
+def replace_img_slide(slide, img_shape, img_path):
+    # Step 1: 读取新图像的二进制
     with open(img_path, 'rb') as f:
-        rImgBlob = f.read()
+        new_img_blob = f.read()
 
-    # replace
-    imgPart._blob = rImgBlob
+    # Step 2: 替换图片内容
+    img_pic = img_shape._pic
+    img_rid = img_pic.xpath('./p:blipFill/a:blip/@r:embed')[0]
+    img_part = slide.part.related_part(img_rid)
+    img_part._blob = new_img_blob
+
+    # Step 3: 获取新图片的尺寸（以像素为单位）
+    with Image.open(img_path) as im:
+        px_width, px_height = im.size
+        dpi = im.info.get("dpi", (96, 96))  # 有些图片不含 DPI 信息，默认 96
+        inch_width = px_width / dpi[0]
+        inch_height = px_height / dpi[1]
+
+    # Step 4: 调整图片形状尺寸（单位为 EMU）
+    img_shape.width = Inches(inch_width)
+    img_shape.height = Inches(inch_height)

--- a/template_pptx_jinja/render.py
+++ b/template_pptx_jinja/render.py
@@ -69,23 +69,23 @@ class PPTXRendering:
         while i < len(runs):
             text = runs[i].text or ""
             if "{{" in text:
-                # 找到 '{{'，开始合并
+                # Found '{{', start merging
                 merged = text
                 j = i + 1
-                # 不断把后续 run 加过来，直到找到 '}}' 或跑完
+                # Keep adding subsequent runs until '}}' found or end reached
                 while j < len(runs) and "}}" not in merged:
                     merged += runs[j].text or ""
                     j += 1
                 if "}}" in merged:
-                    # 合并成功：把 merged 放到第 i 个 run
+                    # Merge successful: put merged content in the i-th run
                     runs[i].text = merged
-                    # 清空中间那些 run 的文本，只保留它们的格式
+                    # Clear text in intermediate runs while preserving their formatting
                     for k in range(i + 1, j):
                         runs[k].text = ""
-                    # 跳过已处理的片段
+                    # Skip processed segments
                     i = j
                 else:
-                    # 没找到闭合就退出
+                    # Exit if no closing tag found
                     break
             else:
                 i += 1

--- a/template_pptx_jinja/render.py
+++ b/template_pptx_jinja/render.py
@@ -61,8 +61,8 @@ class PPTXRendering:
             self._render_paragraph(paragraph)
     def _merge_placeholder_runs(self, paragraph):
         """
-        把跨多个 run 被拆开的 {{ … }} 占位符合并到第一个 run，
-        并清空后续碎片 run 的文本，保留它们的格式。
+        Merge {{...}} placeholders split across multiple runs into the first run,
+        clear text in subsequent fragment runs while preserving their formatting.
         """
         runs = paragraph.runs
         i = 0
@@ -91,9 +91,9 @@ class PPTXRendering:
                 i += 1
 
     def _render_paragraph(self, paragraph):
-        # 1⃣️ 先把跨 run 的 {{…}} 合并
+        # 1. First merge {{...}} across runs
         self._merge_placeholder_runs(paragraph)
-        # 2⃣️ 再按 run 渲染（你的旧逻辑）
+        # 2. Then render by run (original logic)
         for run in paragraph.runs:
             self._render_run(run)
 


### PR DESCRIPTION
This PR addresses an issue where replaced images in slides remained constrained to the original image's dimensions, causing improper scaling or distortion. The changes ensure that new images automatically adjust to their native dimensions while maintaining correct proportions and aspect ratio.

## Key Fixes & Improvements:
1. Fixed image replacement sizing:
- - Added logic to read the new image's pixel dimensions
- - Implemented DPI-based size calculation (pixels to inches)
- - Adjusted slide shapes to match the new image's dimensions
- - Enhanced auto-scaling & positioning:

2. Optimized replace_img_slide for smoother image replacement
- - Added auto-scaling to prevent new images from exceeding the original area
- - Preserved the original image's center position for proper alignment

## Testing Notes:
1. Verify that replaced images now scale correctly without distortion
2. Check that new images remain centered within their original bounds

![PixPin_2025-04-19_07-14-04](https://github.com/user-attachments/assets/ba526a48-9549-4a02-bc17-b29df60cf91e)
![PixPin_2025-04-19_07-14-15](https://github.com/user-attachments/assets/ce718a53-2763-4e78-864b-d6eb98288bf1)
